### PR TITLE
Truncate long job arguments

### DIFF
--- a/app/helpers/mission_control/jobs/jobs_helper.rb
+++ b/app/helpers/mission_control/jobs/jobs_helper.rb
@@ -1,10 +1,12 @@
 module MissionControl::Jobs::JobsHelper
+  MAX_ARGUMENTS_LENGTH = 500
+
   def job_title(job)
     job.job_class_name
   end
 
   def job_arguments(job)
-    renderable_job_arguments_for(job).join(", ")
+    serialized_arguments = renderable_job_arguments_for(job).join(", ").truncate(MAX_ARGUMENTS_LENGTH)
   end
 
   def failed_job_error(job)


### PR DESCRIPTION
### How to test
- Enqueue a job with a long input argument with DummyJob.perform_later(sleep_time: "a"*600)
- Point to this branch by updating Gemfie with gem "mission_control-jobs", git: "https://github.com/fullscript/mission_control-jobs.git", branch: "truncate-job-arguments"
- Run `bundle install` and restart your Rails server
- Navigate to http://localhost:3000/a/jobs/applications/hwadmin/queues/within_1_minute?server_id=solid_queue
Ensure that the input arguments are truncated.