### PR TITLE
Removed poorly performing filters

### DIFF
--- a/app/controllers/concerns/mission_control/jobs/job_filters.rb
+++ b/app/controllers/concerns/mission_control/jobs/job_filters.rb
@@ -9,11 +9,15 @@ module MissionControl::Jobs::JobFilters
 
   private
     def set_filters
-      @job_filters = {
-        job_class_name: params.dig(:filter, :job_class_name).to_s.strip.presence,
-        queue_name: params.dig(:filter, :queue_name).to_s.strip.presence,
-        finished_at: finished_at_range_params
-      }.compact
+      if filtering_disabled?
+        @job_filters = {}
+      else
+        @job_filters = {
+          job_class_name: finished_status? ? nil : params.dig(:filter, :job_class_name).to_s.strip.presence,
+          queue_name: params.dig(:filter, :queue_name).to_s.strip.presence,
+          finished_at: finished_at_range_params
+        }.compact
+      end
     end
 
     def active_filters?
@@ -37,5 +41,13 @@ module MissionControl::Jobs::JobFilters
 
     def parse_with_time_zone(date)
       Time.zone.parse(date) if date.present?
+    end
+
+    def filtering_disabled?
+      %w[in_progress blocked scheduled].include?(params[:status])
+    end
+
+    def finished_status?
+      params[:status] == "finished"
     end
 end

--- a/app/views/mission_control/jobs/jobs/_filters.html.erb
+++ b/app/views/mission_control/jobs/jobs/_filters.html.erb
@@ -3,12 +3,14 @@
     data: { controller: "form", action: "input->form#debouncedSubmit" } do |form| %>
 
     <div class="field is-grouped">
-      <div class="control">
-        <%= form.label :job_class_name, class: "label" %>
-        <div class="select is-rounded">
-          <%= form.text_field :job_class_name, value: @job_filters[:job_class_name], class: "input", list: "job-classes", placeholder: "Filter by job class...", autocomplete: "off" %>
+      <% unless jobs_status == "finished" %>
+        <div class="control">
+          <%= form.label :job_class_name, class: "label" %>
+          <div class="select is-rounded">
+            <%= form.text_field :job_class_name, value: @job_filters[:job_class_name], class: "input", list: "job-classes", placeholder: "Filter by job class...", autocomplete: "off" %>
+          </div>
         </div>
-      </div>
+      <% end %>
 
       <div class="control">
         <%= form.label :queue_name, class: "label" %>

--- a/app/views/mission_control/jobs/jobs/index.html.erb
+++ b/app/views/mission_control/jobs/jobs/index.html.erb
@@ -5,7 +5,9 @@
 <% else %>
   <div data-controller="jobs">
     <div class="level is-flex-wrap-wrap">
-      <%= render "mission_control/jobs/jobs/filters", job_class_names: @job_class_names, queue_names: @queue_names %>
+      <% unless %w[in_progress blocked scheduled].include?(jobs_status.to_s) %>
+        <%= render "mission_control/jobs/jobs/filters", job_class_names: @job_class_names, queue_names: @queue_names %>
+      <% end %>
       <%= render "mission_control/jobs/jobs/toolbar", jobs_count: @jobs_count %>
     </div>
 

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -137,27 +137,16 @@ class MissionControl::Jobs::JobsControllerTest < ActionDispatch::IntegrationTest
     I18n.available_locales = previous_locales
   end
 
-  test "empty string after stripping whitespace does not filter" do
+  test "job_class_name filter is ignored for finished jobs" do
     DummyJob.perform_later(42)
     DummyReloadedJob.perform_later(42)
     perform_enqueued_jobs_async
 
-    get mission_control_jobs.application_jobs_url(@application, :finished, filter: { job_class_name: " \n\t \n\t" })
+    get mission_control_jobs.application_jobs_url(@application, :finished, filter: { job_class_name: "DummyJob" })
     assert_response :ok
     assert_select "tr.job", 2
     assert_select "tr.job", /DummyJob/
     assert_select "tr.job", /DummyReloadedJob/
-  end
-
-  test "get jobs filtered by class name ignoring surrounding white spaces, newlines and tabs" do
-    DummyJob.perform_later(42)
-    DummyReloadedJob.perform_later(42)
-    perform_enqueued_jobs_async
-
-    get mission_control_jobs.application_jobs_url(@application, :finished, filter: { job_class_name: " \n\tDummyJob \n\t" })
-    assert_response :ok
-    assert_select "tr.job", 1
-    assert_select "tr.job", /DummyJob/
   end
 
   test "get jobs filtered by queue name ignoring surrounding white spaces, newlines and tabs" do


### PR DESCRIPTION
### Purpose

Because of the limited set of indexes on some of the SolidQueue tables, many of the filters on the mission control pages perform __very__ poorly. See some of the ones at the top of [this list](https://fullscript.sentry.io/insights/backend/database/?environment=production&globalFilter=%7B%22dataset%22%3A%22spans%22%2C%22tag%22%3A%7B%22key%22%3A%22span.system%22%2C%22name%22%3A%22span.system%22%2C%22kind%22%3A%22tag%22%7D%2C%22value%22%3A%22%22%7D&globalFilter=%7B%22dataset%22%3A%22spans%22%2C%22tag%22%3A%7B%22key%22%3A%22span.action%22%2C%22name%22%3A%22span.action%22%2C%22kind%22%3A%22tag%22%7D%2C%22value%22%3A%22%22%7D&globalFilter=%7B%22dataset%22%3A%22spans%22%2C%22tag%22%3A%7B%22key%22%3A%22span.domain%22%2C%22name%22%3A%22span.domain%22%2C%22kind%22%3A%22tag%22%7D%2C%22value%22%3A%22%22%7D&globalFilter=%7B%22dataset%22%3A%22spans%22%2C%22tag%22%3A%7B%22key%22%3A%22span.description%22%2C%22name%22%3A%22span.description%22%2C%22kind%22%3A%22tag%22%7D%2C%22value%22%3A%22span.description%3A%EF%80%8DContains%EF%80%8Dsolid_queue%22%7D&project=6071554&release=&statsPeriod=7d). We would prefer not to add more indexes because these tables are very write heavy and so, this PR removes some of the problematic pages.

### How to test

- In hw-admin, update the Gemfile to point to this branch with `gem "mission_control-jobs", git: "https://github.com/fullscript/mission_control-jobs.git", branch: "remove-finished-jobs-filtering" `
- Restart your Rails server
- Ensure that you have finished jobs, failed jobs, blocked jobs and in-progress jobs. If you don't have any, use the scripts below
- Make sure `bin/jobs` is running
- Navigate to `/a/jobs`
- Ensure that the "Failed jobs" tab still has filters for class name and queue name
- Ensure that "In Progress jobs" has no filters available
- Ensure that "Blocked jobs" has no filters available
- Ensure that "Finished jobs" has no filter for class name (took down prod last week)


```ruby
# for failed jobs, update DummyJob with
raise "oh noes" if sleep_time == 5
# then run
90.times do DummyJob.perform_later

# For finished jobs, run
500.times do DummyJob.perform_later(sleep_time: 0) end

# For an in-progress job, run
DummyJob.perform_later(sleep_time: 60)
```

### Notes

This PR was completely generated by Claude